### PR TITLE
Updated Dependencies to Latest Version

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS demo.c lcd.c touch.c
                     INCLUDE_DIRS "."
-                    REQUIRES esp_lcd driver 
+                    REQUIRES esp_driver_ledc
                     )

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   lvgl/lvgl: "^9.5.0"
 
   idf:
-    version: ">=5.2.0"
+    version: ">=6.0.0"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,8 +1,8 @@
 dependencies:
-  espressif/esp_lcd_ili9341: "^2.0.0"
-  atanisoft/esp_lcd_touch_xpt2046: "^1.0.3"
-  espressif/esp_lvgl_port: "^2.0.0"
-  lvgl/lvgl: "^9.1.0"
+  espressif/esp_lcd_ili9341: "^2.0.2"
+  atanisoft/esp_lcd_touch_xpt2046: "^1.0.6"
+  espressif/esp_lvgl_port: "^2.7.2"
+  lvgl/lvgl: "^9.5.0"
 
   idf:
     version: ">=5.2.0"

--- a/main/lcd.c
+++ b/main/lcd.c
@@ -13,7 +13,6 @@
 #include <esp_lcd_panel_io.h>
 #include <esp_lcd_panel_vendor.h>
 #include <esp_lcd_panel_ops.h>
-#include <esp_timer.h>
 #include <driver/gpio.h>
 #include <driver/ledc.h>
 #include <driver/spi_master.h>
@@ -126,9 +125,9 @@ esp_err_t app_lcd_init(esp_lcd_panel_io_handle_t *lcd_io, esp_lcd_panel_handle_t
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = LCD_RESET,
         #ifdef CYD_ILI9341
-        .color_space = ESP_LCD_COLOR_SPACE_BGR,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_BGR,
         #else
-        .color_space = ESP_LCD_COLOR_SPACE_RGB,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
         #endif
         .bits_per_pixel = LCD_BITS_PIXEL,
     };

--- a/main/touch.c
+++ b/main/touch.c
@@ -4,7 +4,6 @@
 
 #include <esp_log.h>
 #include <esp_err.h>
-#include <esp_timer.h>
 #include <esp_lcd_touch.h>
 #include <esp_lcd_touch_xpt2046.h>
 


### PR DESCRIPTION
**Updated Dependencies to Latest Version:**
- idf 5.2.0 -> 6.0.0
- espressif/esp_lcd_ili9341 2.0.0 -> 2.0.2
- atanisoft/esp_lcd_touch_xpt2046 1.0.3 -> 1.0.6
- espressif/esp_lvgl_port: 2.0.0 -> 2.7.2
- lvgl/lvgl 9.1.0 -> 9.5.0

Replaced `esp_lcd` and `driver` by `esp_driver_ledc` in CMakeLists.txt
Removed esp_timer.h inclusion.
Replaced `color_space` by `rgb_ele_order`